### PR TITLE
Introduce getPaymentUrlFromToken

### DIFF
--- a/src/lib/YouCanPay.ts
+++ b/src/lib/YouCanPay.ts
@@ -27,17 +27,15 @@ export class YouCanPay {
   }
 
   public async getPaymentUrl(data: TokenInput, lang: Lang): Promise<string> {
-    const payload = { ...data, pri_key: this.privateKey };
-    const axiosAdapter = new AxiosAdapter();
+    const token = await this.getToken(data);
 
-    const tokenEndpoint = new TokenEndpoint(
-      this.isSandBoxMode,
-      axiosAdapter,
-      payload
-    );
+    return this.getPaymentUrlFromToken(token, lang);
+  }
 
-    const token = await tokenEndpoint.call();
-
+  public async getPaymentUrlFromToken(
+    token: IToken,
+    lang: Lang
+  ): Promise<string> {
     return `${BASE_URL}${this.isSandBoxMode ? 'sandbox/' : ''}payment-form/${
       token.id
     }?lang=${lang}`;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR will make it easier to get a payment token and a payment URL for the same payment order.

- **What is the current behavior?** (You can also link to an open issue here)
The current behavior makes it impossible to generate a payment URL and get a token simultaneously without re-implementing the URL generation part.
This doesn't make it maintainable if YCP decides to change something in how URLs are composed.

- **What is the new behavior (if this is a feature change)?**
The token and URL generation are separated into different methods while keeping BC and introducing a new method that can generate the Payment URL from the fetched token

- **Other information**:
